### PR TITLE
Updated to Noether 0.16

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -9,4 +9,4 @@
 - git:
     local-name: noether
     uri: https://github.com/ros-industrial/noether.git
-    version: 0.15.4
+    version: 0.16.0


### PR DESCRIPTION
This PR updates the repo to use Noether version 0.16, which includes a revised plane slicer raster planner and several new tool path modifiers.